### PR TITLE
fix: add markdown quality check and fix Lambda logging

### DIFF
--- a/index.py
+++ b/index.py
@@ -14,7 +14,7 @@ import os
 from typing import Dict, Any
 
 from models import DocumentInfo, PDFProcessingResponse
-from quality_check import run_early_quality_check
+from quality_check import run_early_quality_check, run_markdown_quality_check
 from extraction import (
     extract_markdown_parallel,
     extract_words,
@@ -24,9 +24,13 @@ from extraction import (
 )
 from s3_output import should_use_s3_output, write_results_to_s3
 
-# Configure logging
+# Configure logging — AWS Lambda pre-configures the root logger,
+# so basicConfig() is a no-op. Explicitly set the level instead.
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+# Also ensure root logger level allows INFO through
+logging.getLogger().setLevel(logging.INFO)
 
 # Log library versions at module load time
 import pymupdf4llm
@@ -101,6 +105,22 @@ def process_pdf_from_s3(
                 # Step 3: Parallel markdown extraction
                 page_chunks = extract_markdown_parallel(local_path, page_count)
 
+                # Step 3b: Post-extraction markdown quality check
+                md_passed, md_stats = run_markdown_quality_check(page_chunks)
+                logger.info(
+                    "Markdown quality check: passed=%s, stats=%s", md_passed, md_stats
+                )
+                if not md_passed:
+                    return {
+                        "success": False,
+                        "error": md_stats.get(
+                            "failure_reason", "Markdown quality check failed"
+                        ),
+                        "error_type": "MarkdownQualityCheckFailed",
+                        "page_count": int(page_count),
+                        "word_count": 0,
+                    }
+
                 # Step 4: Word bounding boxes (fast, ~0.3s)
                 word_bounding_boxes = extract_words(pdf_document)
 
@@ -112,6 +132,13 @@ def process_pdf_from_s3(
                 structured_data = build_structured_data(
                     page_chunks, graphics_mode, per_page_graphics
                 )
+
+            logger.info(
+                "Extraction complete: pages=%d, words=%d, structured_pages=%d",
+                page_count,
+                len(word_bounding_boxes),
+                len(structured_data),
+            )
 
             # Step 6: Output
             if should_use_s3_output(page_count, output_bucket, request_id):

--- a/quality_check.py
+++ b/quality_check.py
@@ -115,6 +115,83 @@ def run_early_quality_check(pdf_path: str) -> Tuple[bool, Dict[str, Any]]:
         doc.close()
 
 
+def run_markdown_quality_check(
+    page_chunks: list,
+) -> Tuple[bool, Dict[str, Any]]:
+    """
+    Post-extraction quality check on pymupdf4llm markdown output.
+
+    Catches the gap where word extraction passes (PDF has selectable text)
+    but pymupdf4llm produces empty/trivial markdown. This happens with
+    certain PDF structures (Type3 fonts, Chrome-generated PDFs with
+    full-page background images, XFA forms).
+
+    Returns:
+        (passed, stats) where stats contains page-level markdown metrics
+        and failure_reason (if failed).
+    """
+    if not page_chunks:
+        return False, {
+            "failure_reason": "No markdown chunks produced",
+            "pages_with_content": 0,
+            "total_md_chars": 0,
+        }
+
+    total_pages = len(page_chunks)
+    pages_with_content = 0
+    total_md_chars = 0
+    empty_pages = []
+
+    for i, chunk in enumerate(page_chunks):
+        text = (chunk.get("text") or "").strip()
+        char_count = len(text)
+        total_md_chars += char_count
+        if char_count > 0:
+            pages_with_content += 1
+        else:
+            empty_pages.append(i + 1)  # 1-indexed
+
+    md_chars_per_page = round(total_md_chars / total_pages, 1)
+
+    stats = {
+        "pages_with_content": pages_with_content,
+        "total_pages": total_pages,
+        "total_md_chars": total_md_chars,
+        "md_chars_per_page": md_chars_per_page,
+    }
+
+    # All pages produced empty markdown
+    if pages_with_content == 0:
+        stats["failure_reason"] = "All pages produced empty markdown"
+        stats["empty_pages"] = empty_pages
+        return False, stats
+
+    # Less than 20% of pages have content (for docs with 5+ pages)
+    if total_pages >= 5 and pages_with_content / total_pages < 0.2:
+        stats["failure_reason"] = (
+            f"Too few pages with markdown content "
+            f"({pages_with_content}/{total_pages})"
+        )
+        stats["empty_pages"] = empty_pages
+        return False, stats
+
+    # Total content is trivially short (less than 20 chars per page average)
+    if md_chars_per_page < 20:
+        stats["failure_reason"] = (
+            f"Markdown content too sparse ({md_chars_per_page} chars/page avg)"
+        )
+        return False, stats
+
+    if empty_pages:
+        logger.info(
+            "Markdown quality check: %d empty pages: %s",
+            len(empty_pages),
+            empty_pages[:20],
+        )
+
+    return True, stats
+
+
 def _check_gibberish(text: str) -> str | None:
     """
     Check concatenated word text for gibberish/corruption patterns.


### PR DESCRIPTION
## Summary
- **Markdown quality check**: Adds `run_markdown_quality_check()` that runs after `pymupdf4llm.to_markdown()` to detect empty/sparse output. Returns `success=False` with `error_type=MarkdownQualityCheckFailed` so the Elixir side triggers Azure OCR fallback.
- **Logging fix**: AWS Lambda pre-configures the root logger, making `logging.basicConfig()` a no-op. Explicitly sets `logger.setLevel(logging.INFO)` and root logger level so all `logger.info()` calls appear in CloudWatch.
- **Extraction summary log**: Logs `pages=, words=, structured_pages=` after extraction completes.

## Background
Certain PDFs (Chrome/Skia-generated with Type3 fonts + full-page background images) pass the early word-based quality check (`fitz.get_text("words")` extracts text fine) but `pymupdf4llm.to_markdown()` silently returns empty strings for all pages. The Lambda returned `success=True` with empty page content, so Azure fallback never triggered.

Verified locally on `AR_bankStatement-1a.pdf`: 1140 words extracted, 0 chars of markdown across all 7 pages.

## Test plan
- [ ] Deploy to dev Lambda
- [ ] Upload `AR_bankStatement-1a.pdf` — should now return `success=False` with `MarkdownQualityCheckFailed`, triggering Azure fallback
- [ ] Upload a normal PDF — should pass both checks and return markdown as before
- [ ] Verify CloudWatch logs now show `logger.info()` output (Downloaded, Quality check, Markdown quality check, Extraction complete)