### PR TITLE
fix(layer): build python3.12-ABI layer in no-Docker path + ABI guard

### DIFF
--- a/build-layer-no-docker.sh
+++ b/build-layer-no-docker.sh
@@ -5,35 +5,30 @@
 # Use only when Docker is not available
 set -e
 
-echo "Building Lambda Layer WITHOUT Docker (fallback method)..."
-echo "WARNING: This may not be fully compatible with Lambda's Python 3.12 runtime"
+echo "Building Lambda Layer WITHOUT Docker (cross-targeted to the Lambda runtime ABI)..."
 
 # Clean up any existing build artifacts
 rm -rf layer-build/
 mkdir -p layer-build/python/lib/python3.12/site-packages/
 
-echo "Installing dependencies locally..."
-# Note: This fallback script may not work for PyMuPDF 1.28.x on non-AL2023 systems
-# due to glibc requirements. Use Docker-based build (build-layer.sh) for production.
+echo "Installing dependencies as Lambda-runtime (python3.12 / manylinux x86_64) wheels..."
+# Cross-target the Lambda runtime ABI regardless of the build host's Python. The host
+# running this no-Docker path (notably the Pulumi deploy runner) is frequently NOT
+# python3.12 — it has shipped python3.13 — and a plain `pip install` there fetches
+# cp313 wheels for numpy/onnxruntime. Those fail to import under the python3.12 Lambda
+# runtime, so `import pymupdf.layout` is caught and pymupdf4llm silently drops to its
+# non-layout path → truncated OCR on Skia / vector-graphics PDFs.
+#
+# --only-binary=:all: forbids any host-Python source build; --abi/--implementation/
+# --python-version/--platform pin every wheel to the runtime ABI. There is intentionally
+# NO host-Python fallback: fail the build rather than ship an ABI-mismatched layer.
 pip3 install \
+    --python-version 3.12 --implementation cp --abi cp312 \
+    --platform manylinux_2_28_x86_64 --platform manylinux_2_17_x86_64 \
+    --only-binary=:all: --no-cache-dir \
     PyMuPDF==1.27.2.3 \
     pymupdf4llm==1.27.2.3 \
-    -t layer-build/python/lib/python3.12/site-packages/ --no-cache-dir || {
-        echo "ERROR: pip install failed!"
-        echo "Trying with --user and manual copy..."
-        pip3 install --user \
-            PyMuPDF==1.27.2.3 \
-            pymupdf4llm==1.27.2.3 \
-            --no-cache-dir
-        
-        # Find user site-packages and copy
-        USER_SITE=$(python3 -c "import site; print(site.USER_SITE)")
-        if [ -d "$USER_SITE" ]; then
-            echo "Copying from user site-packages: $USER_SITE"
-            mkdir -p layer-build/python/lib/python3.12/site-packages/
-            cp -r "$USER_SITE"/* layer-build/python/lib/python3.12/site-packages/ 2>/dev/null || true
-        fi
-    }
+    -t layer-build/python/lib/python3.12/site-packages/
 
 # Basic cleanup
 cd layer-build/python/lib/python3.12/site-packages/
@@ -60,7 +55,7 @@ fi
 
 echo "Fallback Lambda layer package created: dependencies-layer.zip"
 echo "Size: $(ls -lh dependencies-layer.zip | awk '{print $5}')"
-echo "WARNING: This layer was built without Docker and may not be fully compatible with Lambda runtime"
+echo "Layer built without Docker, cross-targeted to python3.12 / manylinux x86_64."
 
 # Copy to Pulumi build directory (following Pulumi best practices)
 echo "=== Copying to Pulumi build directory ==="

--- a/ci-smart-build.sh
+++ b/ci-smart-build.sh
@@ -67,7 +67,18 @@ fi
 if [ "$NEEDS_BUILD" = true ]; then
     echo "Building Lambda package..."
     ./build.sh
-    
+
+    # Fail-closed ABI guard. The layer's compiled extensions MUST match the Lambda
+    # runtime (python3.12). If the build host resolved cp313 wheels (numpy/onnxruntime),
+    # they import-fail under python3.12 and pymupdf4llm silently drops its layout mode →
+    # truncated OCR. Better to fail the build (and the deploy) than ship a broken layer.
+    if unzip -l dependencies-layer.zip | grep -oE 'cpython-3[0-9]+' | grep -qv 'cpython-312'; then
+        echo "FATAL: dependencies-layer.zip contains non-cpython-312 extensions (runtime is python3.12):"
+        unzip -l dependencies-layer.zip | grep -oE 'cpython-3[0-9]+' | sort -u
+        exit 1
+    fi
+    echo "ABI guard passed: layer compiled extensions are cpython-312 only."
+
     # Save the current hash
     echo "$CURRENT_HASH" > "$HASH_FILE"
     echo "Build complete. Hash saved: $CURRENT_HASH"


### PR DESCRIPTION
## Problem

The pymupdf4llm **1.27.2.3** bump (PR #8) deployed correctly to the layer, but the Skia/vector-graphics text-loss regression still reproduces in **prod and prod-eu** while **staging is fixed** — same submodule source, same `graphics_mode`, same input PDF.

Root cause is a **build-host Python drift**, not a code or version difference:

| | staging | prod / prod-eu |
|---|---|---|
| Lambda runtime | python3.12 | python3.12 |
| Layer compiled-ext ABI | `cpython-312` ✅ | `cpython-313` ❌ |

Staging deploys via a **GitHub Action with Docker** (`public.ecr.aws/lambda/python:3.12`) → correct cp312 wheels. Prod/prod-eu deploy via the Pulumi console, whose runner has **no working Docker**, so `build.sh` silently falls back to `build-layer-no-docker.sh`, which pip-installed with the **host interpreter (python3.13)**. Only `numpy` and `onnxruntime` are Python-version-locked (`cp312-cp312`) — as cp313 they can't import under the 3.12 runtime, so `import pymupdf.layout` (wrapped in `try/except ImportError`) is caught and pymupdf4llm silently drops to its non-layout path → the Skia header is lost and the truncated result sails past the 0.75 QC gate.

## Fix (minimal, targeted)

- **`build-layer-no-docker.sh`**: cross-target the runtime ABI regardless of the build host's Python — `--python-version 3.12 --implementation cp --abi cp312 --platform manylinux_2_28_x86_64 --platform manylinux_2_17_x86_64 --only-binary=:all:`. Removes the host-Python `--user` fallback so the build **fails closed** instead of shipping a mismatched layer.
- **`ci-smart-build.sh`**: fail the build if the produced layer contains any non-`cpython-312` compiled extension — the tripwire that makes this class of bug impossible to ship silently.

The Docker path (`build-layer.sh`, used by staging) is unchanged.

## Validation

Platform tags verified against the wheels actually baked into the working staging layer: `numpy`/`onnxruntime` ship `manylinux_2_28` + `manylinux_2_27` cp312 wheels (covered by the 2_28/2_17 tags); `pymupdf`/`pymupdf_layout`/`protobuf` are `abi3`; `pymupdf4llm`/`networkx`/`flatbuffers` are pure-python. CI’s Docker build remains the primary path; the ABI guard is the backstop.

## Deploy / remediation sequence

1. Merge → bump the `lambda/pdf-processor` submodule pointer in the app repo.
2. Redeploy **prod-eu and prod** from the Pulumi console; confirm the layer’s ABI tags are `cpython-312` and the Delivery Note extracts in full.
3. Lift the prod-eu Azure-fallback mitigation (`aws lambda delete-function-concurrency --function-name pdf-processor-lambda-prod-eu --region eu-west-1`).

Interim mitigation in place: prod-eu is at reserved-concurrency 0 → OCR falls back to Azure (full-text) until the corrected layer is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
